### PR TITLE
added example for playTrackNumber(<number>)

### DIFF
--- a/examples/Example1_Terminal_MP3_Player/Example1_Terminal_MP3_Player.ino
+++ b/examples/Example1_Terminal_MP3_Player/Example1_Terminal_MP3_Player.ino
@@ -1,6 +1,5 @@
 /*
   WT2003 S Example1_Terminal_MP3_Player
-
   This example makes an MP3 player that can be controlled from the terminal window on a computer. 
   It exposes the full set of commands that are available for the WT2003S
  
@@ -9,10 +8,8 @@
   SparkFun Electronics
   Date: July 5th 2018, Aug 9 2018
   License: This code is public domain but you buy me a beer if you use this and we meet someday (Beerware license).
-
   Feel like supporting our work? Buy a board from SparkFun!
   https://www.sparkfun.com/products/14810
-
   Hardware Connections:
   WT2003S Breakout Pin ---> Arduino Pin 
   -------------------------------------
@@ -21,7 +18,6 @@
   5V                   --->  5V
   GND                  ---> GND
   BUSY                 --->   7 (Optional)
-
   Don't forget to load some MP3s on your sdCard and plug it in too!
 */
 
@@ -188,6 +184,10 @@ void loop() {
     { 
 		MP3.setPlaymodeRandom();
 	}
+	else if(cmd == '2')
+    { 
+		MP3.playTrackNumber(2);
+	}
 	else
     {
       printMenu();
@@ -221,6 +221,8 @@ void printMenu( void )
   Serial.println("'x'         : set playmode single loop");
   Serial.println("'y'         : set playmode all loop");
   Serial.println("'z'         : set playmode random");
+  Serial.println("'2'         : play the file that was copied to the SD card as the second file");
+  Serial.println("              (Yes, this really does go by copy order.)");
   Serial.println();
 }
 

--- a/examples/Example1_Terminal_MP3_Player/Example1_Terminal_MP3_Player.ino
+++ b/examples/Example1_Terminal_MP3_Player/Example1_Terminal_MP3_Player.ino
@@ -1,5 +1,6 @@
 /*
   WT2003 S Example1_Terminal_MP3_Player
+
   This example makes an MP3 player that can be controlled from the terminal window on a computer. 
   It exposes the full set of commands that are available for the WT2003S
  
@@ -8,8 +9,10 @@
   SparkFun Electronics
   Date: July 5th 2018, Aug 9 2018
   License: This code is public domain but you buy me a beer if you use this and we meet someday (Beerware license).
+
   Feel like supporting our work? Buy a board from SparkFun!
   https://www.sparkfun.com/products/14810
+
   Hardware Connections:
   WT2003S Breakout Pin ---> Arduino Pin 
   -------------------------------------
@@ -18,6 +21,7 @@
   5V                   --->  5V
   GND                  ---> GND
   BUSY                 --->   7 (Optional)
+
   Don't forget to load some MP3s on your sdCard and plug it in too!
 */
 
@@ -170,25 +174,25 @@ void loop() {
     }
     else if(cmd == 'w')
     { 
-    MP3.setPlaymodeSingleNoLoop();
+		MP3.setPlaymodeSingleNoLoop();
     }  
     else if(cmd == 'x')
     { 
-    MP3.setPlaymodeSingleLoop();
-  }
+		MP3.setPlaymodeSingleLoop();
+	}
     else if(cmd == 'y')
     { 
-    MP3.setPlaymodeAllLoop();
-  }    
-  else if(cmd == 'z')
+		MP3.setPlaymodeAllLoop();
+	}    
+	else if(cmd == 'z')
     { 
-    MP3.setPlaymodeRandom();
-  }
-  else if(cmd == '2')
+		MP3.setPlaymodeRandom();
+	}
+	else if(cmd == '2')
     { 
-    MP3.playTrackNumber(2);
-  }
-  else
+        MP3.playTrackNumber(2);
+    }
+    else
     {
       printMenu();
     }
@@ -225,3 +229,4 @@ void printMenu( void )
   Serial.println("              (Yes, this really does go by copy order.)");
   Serial.println();
 }
+

--- a/examples/Example1_Terminal_MP3_Player/Example1_Terminal_MP3_Player.ino
+++ b/examples/Example1_Terminal_MP3_Player/Example1_Terminal_MP3_Player.ino
@@ -1,4 +1,5 @@
 
+
 /*
   WT2003 S Example1_Terminal_MP3_Player
   This example makes an MP3 player that can be controlled from the terminal window on a computer. 

--- a/examples/Example1_Terminal_MP3_Player/Example1_Terminal_MP3_Player.ino
+++ b/examples/Example1_Terminal_MP3_Player/Example1_Terminal_MP3_Player.ino
@@ -1,3 +1,4 @@
+
 /*
   WT2003 S Example1_Terminal_MP3_Player
   This example makes an MP3 player that can be controlled from the terminal window on a computer. 
@@ -225,4 +226,3 @@ void printMenu( void )
   Serial.println("              (Yes, this really does go by copy order.)");
   Serial.println();
 }
-

--- a/examples/Example1_Terminal_MP3_Player/Example1_Terminal_MP3_Player.ino
+++ b/examples/Example1_Terminal_MP3_Player/Example1_Terminal_MP3_Player.ino
@@ -1,10 +1,9 @@
 
-
 /*
   WT2003 S Example1_Terminal_MP3_Player
   This example makes an MP3 player that can be controlled from the terminal window on a computer. 
   It exposes the full set of commands that are available for the WT2003S
-  
+ 
   Using the WT2003S MP3 Decoder IC on the SparkFun breakout board with Arduino Uno
   By: Owen Lyke, Tina Tenbergen
   SparkFun Electronics
@@ -172,25 +171,25 @@ void loop() {
     }
     else if(cmd == 'w')
     { 
-		MP3.setPlaymodeSingleNoLoop();
+    MP3.setPlaymodeSingleNoLoop();
     }  
     else if(cmd == 'x')
     { 
-		MP3.setPlaymodeSingleLoop();
-	}
+    MP3.setPlaymodeSingleLoop();
+  }
     else if(cmd == 'y')
     { 
-		MP3.setPlaymodeAllLoop();
-	}    
-	else if(cmd == 'z')
+    MP3.setPlaymodeAllLoop();
+  }    
+  else if(cmd == 'z')
     { 
-		MP3.setPlaymodeRandom();
-	}
-	else if(cmd == '2')
+    MP3.setPlaymodeRandom();
+  }
+  else if(cmd == '2')
     { 
-		MP3.playTrackNumber(2);
-	}
-	else
+    MP3.playTrackNumber(2);
+  }
+  else
     {
       printMenu();
     }

--- a/examples/Example1_Terminal_MP3_Player/Example1_Terminal_MP3_Player.ino
+++ b/examples/Example1_Terminal_MP3_Player/Example1_Terminal_MP3_Player.ino
@@ -1,4 +1,3 @@
-
 /*
   WT2003 S Example1_Terminal_MP3_Player
   This example makes an MP3 player that can be controlled from the terminal window on a computer. 

--- a/examples/Example1_Terminal_MP3_Player/Example1_Terminal_MP3_Player.ino
+++ b/examples/Example1_Terminal_MP3_Player/Example1_Terminal_MP3_Player.ino
@@ -4,7 +4,7 @@
   WT2003 S Example1_Terminal_MP3_Player
   This example makes an MP3 player that can be controlled from the terminal window on a computer. 
   It exposes the full set of commands that are available for the WT2003S
- 
+  
   Using the WT2003S MP3 Decoder IC on the SparkFun breakout board with Arduino Uno
   By: Owen Lyke, Tina Tenbergen
   SparkFun Electronics


### PR DESCRIPTION
Took me a while to figure out that they really did mean the order files are copied to SD card on P28 in https://cdn.sparkfun.com/assets/1/d/b/f/d/WT2003S-16S_Datasheet.pdf so I added an example and a use explanation to the menu. 
There are a lot of commits between my last and this one because I was messing around with the EOL so it would not show as total change in the diff view. Copy and pasting in windows seems to break this, but was able to download file and edit in Notepad++ with only LF as EOL character. 